### PR TITLE
downgrade rest-client for use with rails

### DIFF
--- a/moltin.gemspec
+++ b/moltin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.8"
+  spec.add_dependency "rest-client", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Is 1.8 absolutely needed?

Was having dependency issues with a variety of other gems in my rails 4.2.3 app