### PR TITLE
Support older rest client versions

### DIFF
--- a/moltin.gemspec
+++ b/moltin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.8"
+  spec.add_dependency "rest-client", ">= 1.6", "< 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Rest client version should be >= 1.6 but < 2.0

This will solve #2 without forcing an older version of rest-client on all users