### PR TITLE
Fix issue on to_s for Product

### DIFF
--- a/lib/moltin/api/crud_resource.rb
+++ b/lib/moltin/api/crud_resource.rb
@@ -81,7 +81,11 @@ module Moltin
       def to_s
         _data = {}
         @data.keys.each do |attribute|
-          _data[attribute] = send(attribute) if respond_to?(attribute)
+          if respond_to?(attribute)
+            _data[attribute] = send(attribute)
+          else
+            _data[attribute] = @data[attribute].to_s
+          end
         end
         _data
       end

--- a/lib/moltin/api/crud_resource.rb
+++ b/lib/moltin/api/crud_resource.rb
@@ -81,7 +81,7 @@ module Moltin
       def to_s
         _data = {}
         @data.keys.each do |attribute|
-          _data[attribute] = send(attribute)
+          _data[attribute] = send(attribute) if respond_to?(attribute)
         end
         _data
       end


### PR DESCRIPTION
When I call to_s on a Product, I get an error

```
NoMethodError: undefined method `order' for #<Moltin::Resource::Product:0x007f99e4062400>
project/lib/tasks/seed_moltin.rake:6:in `puts'
project/lib/tasks/seed_moltin.rake:6:in `puts'
project/lib/tasks/seed_moltin.rake:6:in `block in <top (required)>'
project/bin/rails:9:in `require'
project/bin/rails:9:in `<top (required)>'
project/bin/spring:14:in `require'
project/bin/spring:14:in `<top (required)>'
```

I fix this issue by checking if the method exist before calling it.

It need testing (if a object reference the same object we can have an infinite loop).